### PR TITLE
download the mailpit binary from Github releases

### DIFF
--- a/portal/mailpit.go
+++ b/portal/mailpit.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,23 +13,67 @@ import (
 )
 
 var mailpitBin = flag.String("mailpit_bin", "", "Absolute path to the mailpit binary")
+var mailpitTag = flag.String("mailpit_tag", "1.8.2+nsbox.2023110501", "Release tag for the mailpit binary")
 
 var mailpitCmd *exec.Cmd
 
+func downloadMailpit() error {
+	tempDir, err := os.MkdirTemp("", "mailpit_download_")
+	if err != nil {
+		return fmt.Errorf("os.MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	url := fmt.Sprintf("https://github.com/naivesystems/mailpit/releases/download/%s/mailpit-linux-amd64.tar.gz", *mailpitTag)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	tarballPath := filepath.Join(tempDir, "mailpit.tar.gz")
+	out, err := os.Create(tarballPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("tar", "-xzf", tarballPath, "-C", filepath.Dir(*mailpitBin))
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func StartMailpit() error {
+	mailpitDir := filepath.Join(*workdir, "mailpit")
+	if err := os.MkdirAll(mailpitDir, 0700); err != nil {
+		return fmt.Errorf("os.MkdirAll(%s): %v", mailpitDir, err)
+	}
+
 	if *mailpitBin == "" {
-		return errors.New("--mailpit_bin must be specified")
+		err := flag.Set("mailpit_bin", filepath.Join(*workdir, "mailpit", "mailpit"))
+		if err != nil {
+			return fmt.Errorf("failed to set mailpit_bin: %v", err)
+		}
+		if !exists(*mailpitBin) {
+			err := downloadMailpit()
+			if err != nil {
+				return fmt.Errorf("failed to download mailpit: %v", err)
+			}
+		}
 	}
 	if !filepath.IsAbs(*mailpitBin) {
 		return fmt.Errorf("--mailpit_bin %s is not an absolute path", *mailpitBin)
 	}
 	if !exists(*mailpitBin) {
 		return fmt.Errorf("--mailpit_bin %s does not exist", *mailpitBin)
-	}
-
-	mailpitDir := filepath.Join(*workdir, "mailpit")
-	if err := os.MkdirAll(mailpitDir, 0700); err != nil {
-		return fmt.Errorf("os.MkdirAll(%s): %v", mailpitDir, err)
 	}
 
 	mailpitCmd = exec.Command(*mailpitBin,

--- a/workdir/README.md
+++ b/workdir/README.md
@@ -16,7 +16,10 @@ Layout of the workdir:
     │   ├── themes
     │   └── version.txt
     ├── mailpit
-    │   └── mails.db
+    │   ├── LICENSE
+    |   ├── mailpit
+    |   ├── mails.db
+    |   └── README.md
     ├── redmine
     │   ├── data
     │   │   ├── admin_api_key.txt


### PR DESCRIPTION
If --mailpit_bin is empty, it will download a prebuilt binary from Github releases, and mailpit_bin is set as \<workdir\>/mailpit/mailpit.